### PR TITLE
Implement cascading Area/Iteration Path inheritance for new items

### DIFF
--- a/src/components/decomposer/DecomposerPanelContent.tsx
+++ b/src/components/decomposer/DecomposerPanelContent.tsx
@@ -107,6 +107,10 @@ export function DecomposerPanelContent({ initialContext }: { initialContext?: In
 
         const parentType = wi.fields['System.WorkItemType'];
         hierarchyManager.setParentWorkItemType(parentType);
+
+        const areaPath = wi.fields['System.AreaPath'];
+        const iterationPath = wi.fields['System.IterationPath'];
+        hierarchyManager.setOriginalPaths(areaPath, iterationPath);
       } catch (err: unknown) {
         decomposerLogger.error('Error fetching data:', err);
         setError((err as Error).message || 'Failed to load work item data');

--- a/src/core/models/workItemHierarchy.ts
+++ b/src/core/models/workItemHierarchy.ts
@@ -8,4 +8,6 @@ export interface WorkItemNode {
   parentId?: string; // Temporary ID of the parent in the hierarchy
   canPromote?: boolean;
   canDemote?: boolean;
+  areaPath?: string;
+  iterationPath?: string;
 }

--- a/src/managers/workItemHierarchyManager.ts
+++ b/src/managers/workItemHierarchyManager.ts
@@ -21,11 +21,15 @@ export class WorkItemHierarchyManager {
     initialHierarchy: WorkItemNode[] = [],
     parentWorkItemType?: WorkItemTypeName,
     errorHandler?: (_error: string) => void,
+    originalAreaPath?: string,
+    originalIterationPath?: string,
   ) {
     this.stateManager = new WorkItemHierarchyStateManager(
       initialHierarchy,
       parentWorkItemType,
       errorHandler,
+      originalAreaPath,
+      originalIterationPath,
     );
 
     this.typeManager = new WorkItemTypeManager(workItemConfigurations, this.stateManager);
@@ -62,6 +66,10 @@ export class WorkItemHierarchyManager {
   setInitialHierarchy(nodes: WorkItemNode[], parentWorkItemType?: WorkItemTypeName): void {
     this.stateManager.setInitialHierarchy(nodes, parentWorkItemType);
     this.flagManager.updateAllPromoteDemoteFlags();
+  }
+
+  setOriginalPaths(areaPath?: string, iterationPath?: string): void {
+    this.stateManager.setOriginalPaths(areaPath, iterationPath);
   }
 
   clearHierarchy(): void {

--- a/src/managers/workItemHierarchyOperationsManager.ts
+++ b/src/managers/workItemHierarchyOperationsManager.ts
@@ -37,6 +37,10 @@ export class WorkItemHierarchyOperationsManager {
     const itemTitle = title || `New ${childTypeToAdd}`;
     const hierarchy = this.stateManager.getHierarchyRef();
 
+    // Inherit Area Path and Iteration Path from the original work item being decomposed
+    const inheritedAreaPath = this.stateManager.getOriginalAreaPath();
+    const inheritedIterationPath = this.stateManager.getOriginalIterationPath();
+
     const newItem: WorkItemNode = {
       id: `temp-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
       title: itemTitle,
@@ -45,6 +49,8 @@ export class WorkItemHierarchyOperationsManager {
       parentId, // undefined for root nodes
       canPromote: false,
       canDemote: false,
+      areaPath: inheritedAreaPath,
+      iterationPath: inheritedIterationPath,
     };
 
     if (parentId) {

--- a/src/managers/workItemHierarchyStateManager.ts
+++ b/src/managers/workItemHierarchyStateManager.ts
@@ -14,16 +14,22 @@ export class WorkItemHierarchyStateManager {
   private parentWorkItemType: WorkItemTypeName | null = null;
   private hierarchyCount = 0;
   private errorHandler?: (_error: string) => void;
+  private originalAreaPath?: string;
+  private originalIterationPath?: string;
 
   constructor(
     initialHierarchy: WorkItemNode[] = [],
     parentWorkItemType?: WorkItemTypeName,
     errorHandler?: (_error: string) => void,
+    originalAreaPath?: string,
+    originalIterationPath?: string,
   ) {
     this.hierarchy = initialHierarchy ? cloneDeep(initialHierarchy) : [];
     this.parentWorkItemType = parentWorkItemType || null;
     this.hierarchyCount = WorkItemNodeFinder.countNodesRecursive(this.hierarchy);
     this.errorHandler = errorHandler;
+    this.originalAreaPath = originalAreaPath;
+    this.originalIterationPath = originalIterationPath;
   }
 
   /**
@@ -51,6 +57,32 @@ export class WorkItemHierarchyStateManager {
    */
   getParentWorkItemType(): WorkItemTypeName | null {
     return this.parentWorkItemType;
+  }
+
+  /**
+   * Gets the original Area Path from the work item being decomposed.
+   * @returns The original area path or undefined if not set.
+   */
+  getOriginalAreaPath(): string | undefined {
+    return this.originalAreaPath;
+  }
+
+  /**
+   * Gets the original Iteration Path from the work item being decomposed.
+   * @returns The original iteration path or undefined if not set.
+   */
+  getOriginalIterationPath(): string | undefined {
+    return this.originalIterationPath;
+  }
+
+  /**
+   * Sets the original Area Path and Iteration Path from the work item being decomposed.
+   * @param areaPath The original area path.
+   * @param iterationPath The original iteration path.
+   */
+  setOriginalPaths(areaPath?: string, iterationPath?: string): void {
+    this.originalAreaPath = areaPath;
+    this.originalIterationPath = iterationPath;
   }
 
   /**

--- a/src/services/workItemCreationService.ts
+++ b/src/services/workItemCreationService.ts
@@ -61,6 +61,23 @@ const createHierarchyRecursive = async (
         },
       } as JsonPatchOperation);
     }
+
+    // Add Area Path and Iteration Path if present
+    if (node.areaPath) {
+      patchDocument.push({
+        op: Operation.Add,
+        path: '/fields/System.AreaPath',
+        value: node.areaPath,
+      } as JsonPatchOperation);
+    }
+    if (node.iterationPath) {
+      patchDocument.push({
+        op: Operation.Add,
+        path: '/fields/System.IterationPath',
+        value: node.iterationPath,
+      } as JsonPatchOperation);
+    }
+
     try {
       creationLogger.debug(
         `Attempting to create '${node.title}' (${node.type}) under parent ${currentParentId}`,


### PR DESCRIPTION
## Description

This pull request introduces functionality to inherit and propagate the `AreaPath` and `IterationPath` fields from the original work item being decomposed to newly created work items.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update

## Testing

- [X] Changes have been tested in Azure DevOps
- [X] Works with different work item types

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/82104a98-f988-46bb-988b-9d53400f2ddc)
_The bug and tasks have been created with Decomposer._

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
