### PR TITLE
Update comment preview to trim whitespace and handle empty comment

### DIFF
--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -211,8 +211,8 @@ export function SettingsPanel() {
                       className="settings-html-preview-content"
                       dangerouslySetInnerHTML={{
                         __html:
-                          settings.commentText ||
-                          '<span class="secondary-text">Nothing to preview</span>',
+                          settings.commentText?.trim() ||
+                          '<span class="secondary-text"><em>Nothing to preview</em></span>',
                       }}
                     />
                   </div>


### PR DESCRIPTION
## Description

This pull request includes a small improvement to the `SettingsPanel` component in `src/components/settings/SettingsPanel.tsx`. The change ensures that the comment is trimmed before being displayed and updates the fallback preview text to emphasize "Nothing to preview" when comment is empty.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update

## Testing

- [X] Changes have been tested in Azure DevOps
- [X] Works with different work item types
- [X] Responsive across different screen sizes

## Screenshots (if applicable)

_None_

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation accordingly
