### PR TITLE
Bump version and remove preview flags in configuration files

### DIFF
--- a/configs/dev.json
+++ b/configs/dev.json
@@ -1,10 +1,9 @@
 {
     "public": false,
     "galleryFlags": [
-        "Private",
-        "Preview"
+        "Private"
     ],
     "baseUri": "https://localhost:3000",
     "id": "work-item-decomposer-dev",
-    "version": "1.0.0.9"
+    "version": "1.0.1.0"
 }

--- a/configs/prod.json
+++ b/configs/prod.json
@@ -1,7 +1,6 @@
 {
     "public": true,
     "galleryFlags": [
-        "Public",
-        "Preview"
+        "Public"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "webpack.config.js",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "clean": "rimraf dist && rimraf -g *.vsix",
     "clean:modules": "rimraf node_modules && npm i",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": 1,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Work Item Decomposer",
   "id": "work-item-decomposer",
   "publisher": "teociaps",


### PR DESCRIPTION
## Description


This pull request includes version updates across multiple configuration and manifest files to reflect the new version `1.0.1`. Additionally, it removes the `Preview` gallery flag from both development and production configurations.

### Version Updates:

* [`configs/dev.json`](diffhunk://#diff-d1773681e7f888ec1d948ac778e8a8a40b703ad91b7f27ad299536a2519271e4L4-R8): Updated the version from `1.0.0.9` to `1.0.1.0`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R11): Updated the version from `1.0.0` to `1.0.1`.
* [`vss-extension.json`](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2L3-R3): Updated the version from `1.0.0` to `1.0.1`.

### Configuration Changes:

* [`configs/dev.json`](diffhunk://#diff-d1773681e7f888ec1d948ac778e8a8a40b703ad91b7f27ad299536a2519271e4L4-R8): Removed the `Preview` gallery flag from the development configuration.
* [`configs/prod.json`](diffhunk://#diff-cd4fa9eaf21fbae51637cb11eae929a8a5be55ac742f46b1297261b1b361ef4bL4-R4): Removed the `Preview` gallery flag from the production configuration.
