### PR TITLE
Update version to 1.1.1

### DIFF
--- a/configs/dev.json
+++ b/configs/dev.json
@@ -5,5 +5,5 @@
     ],
     "baseUri": "https://localhost:3000",
     "id": "work-item-decomposer-dev",
-    "version": "1.1.0.1"
+    "version": "1.1.1.1"
 }

--- a/marketplace/marketplace.md
+++ b/marketplace/marketplace.md
@@ -110,3 +110,9 @@ for the current list of supported and planned languages.
 <p align="center">
   <em>Start planning smarter—decompose work items with ease!</em>
 </p>
+
+---
+
+<p align="center">
+  <small><em>Note: Extension updates are automatic. If additional permissions are required, you may need to authorize the update in Organization Settings > Extensions. Check our <a href="https://github.com/teociaps/azdo-workitem-decomposer/wiki/FAQ">FAQ</a> for version-specific notes.</em></small>
+</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "azdo-workitem-decomposer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "azure-devops-extension-api": "^4.251.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "webpack.config.js",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "clean": "rimraf dist && rimraf -g *.vsix",
     "clean:modules": "rimraf node_modules && npm i",

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -12,19 +12,39 @@ interface VssExtension {
   [key: string]: any;
 }
 
+interface PackageLockJson {
+  version: string;
+  packages: {
+    "": {
+      version: string;
+      [key: string]: any;
+    };
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const packageJsonPath = path.join(__dirname, '../package.json');
 const vssExtensionPath = path.join(__dirname, '../vss-extension.json');
+const packageLockPath = path.join(__dirname, '../package-lock.json');
 
 try {
   const packageJson: PackageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
   const vssExtension: VssExtension = JSON.parse(fs.readFileSync(vssExtensionPath, 'utf8'));
+  const packageLock: PackageLockJson = JSON.parse(fs.readFileSync(packageLockPath, 'utf8'));
 
+  // Update vss-extension.json version
   vssExtension.version = packageJson.version;
 
+  // Update package-lock.json versions
+  packageLock.version = packageJson.version;
+  packageLock.packages[""].version = packageJson.version;
+
   fs.writeFileSync(vssExtensionPath, JSON.stringify(vssExtension, null, 2) + '\n');
+  fs.writeFileSync(packageLockPath, JSON.stringify(packageLock, null, 2) + '\n');
   console.log(`✅ Synced version to ${packageJson.version}`);
 } catch (error) {
   console.error('❌ Failed to sync version:', error instanceof Error ? error.message : error);

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": 1,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "name": "Work Item Decomposer",
   "id": "work-item-decomposer",
   "publisher": "teociaps",


### PR DESCRIPTION
## Description

This pull request introduces version updates across multiple files, a new interface for syncing version information, and an additional note in the documentation. The most important changes include updating the version number to `1.1.1`, adding logic to synchronize the version across `package-lock.json`, and enhancing the documentation with update instructions.

### Version Updates:
* Updated the version number to `1.1.1` in `configs/dev.json`, `package.json`, and `vss-extension.json` to reflect the latest release. [[1]](diffhunk://#diff-d1773681e7f888ec1d948ac778e8a8a40b703ad91b7f27ad299536a2519271e4L8-R8) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R11) [[3]](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2L3-R3)

### Synchronization Logic:
* Added a new `PackageLockJson` interface and logic in `scripts/sync-version.ts` to synchronize version numbers in `package-lock.json` with `package.json`. This ensures consistency across files.

### Documentation Enhancement:
* Enhanced `marketplace/marketplace.md` by adding a note about automatic extension updates and a link to the FAQ for version-specific details. This provides better guidance for users.