### PR TITLE
Fix: adjust modal positioning offset for better alignment

### DIFF
--- a/src/components/modals/ChildTypeSelectionModal/ChildTypeSelectionModal.tsx
+++ b/src/components/modals/ChildTypeSelectionModal/ChildTypeSelectionModal.tsx
@@ -97,7 +97,7 @@ export function ChildTypeSelectionModal({
       }
     : {
         // Normal positioning below the anchor element
-        top: anchorRect.bottom - containerRect.top + scrollTop + 2,
+        top: anchorRect.bottom - containerRect.top + scrollTop + 15,
         right: containerRect.right - anchorRect.right,
       };
 


### PR DESCRIPTION
## Description

This pull request makes a minor adjustment to the vertical positioning of the `ChildTypeSelectionModal` component. The change increases the spacing between the modal and its anchor element to improve visual alignment.

## Type of change

- [X] Bug fix
- [ ] New feature
- [X] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update

## Testing

- [X] Changes have been tested in Azure DevOps
- [X] Works with different work item types
- [X] Responsive across different screen sizes

## Screenshots (if applicable)

_None_

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
