### PR TITLE
Update save shortcut from ALT+SHIFT+S to ALT+S

### DIFF
--- a/src/components/decomposer/DecomposerPanelActionBar.tsx
+++ b/src/components/decomposer/DecomposerPanelActionBar.tsx
@@ -93,7 +93,7 @@ export function DecomposerPanelActionBar(props: DecomposerPanelActionBarProps) {
   }, [onClosePanel]);
   useContextShortcuts(
     'actionBar',
-    [{ code: ShortcutCode.ALT_SHIFT_S, callback: handleSave }],
+    [{ code: ShortcutCode.ALT_S, callback: handleSave }],
     !isLoading && canSave && !isAnyNodeInDeleteConfirmation,
   );
 

--- a/src/core/shortcuts/shortcutConfiguration.ts
+++ b/src/core/shortcuts/shortcutConfiguration.ts
@@ -27,7 +27,7 @@ export enum ShortcutCode {
   ALT_ARROW_RIGHT = 'ALT_ARROW_RIGHT',
   ALT_SHIFT_N = 'ALT_SHIFT_N',
   ALT_SHIFT_H = 'ALT_SHIFT_H',
-  ALT_SHIFT_S = 'ALT_SHIFT_S',
+  ALT_S = 'ALT_SHIFT_S',
   ALT_COMMA = 'ALT_COMMA',
   ALT_H = 'ALT_H',
   ENTER = 'ENTER',
@@ -144,9 +144,9 @@ export const SHORTCUT_CONFIGURATION: ShortcutDefinition[] = [
     variants: [{ context: 'mainPanel', label: 'Open or close hierarchy viewer' }],
   },
   {
-    key: createKeyCombo('S', { alt: true, shift: true }),
+    key: createKeyCombo('s', { alt: true }),
     label: 'Save hierarchy',
-    code: ShortcutCode.ALT_SHIFT_S,
+    code: ShortcutCode.ALT_S,
     variants: [{ context: 'mainPanel', label: 'Save current hierarchy' }], // Keep in the Main Panel section in the help modal
   },
   {


### PR DESCRIPTION
## Description

This pull request updates the keyboard shortcut for saving a hierarchy in the decomposer panel, from Alt+Shift+S to just Alt+S. Browsers use the Alt+Shift+S for custom functionalities already..

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update

## Testing

- [X] Changes have been tested in Azure DevOps
- [X] Works with different work item types

## Screenshots (if applicable)

_None_

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas