### PR TITLE
Enhance tooltips with keyboard shortcuts for better accessibility

### DIFF
--- a/src/components/decomposer/DecomposerPanelActionBar.tsx
+++ b/src/components/decomposer/DecomposerPanelActionBar.tsx
@@ -10,6 +10,7 @@ import { logger } from '../../core/common/logger';
 import { useContextShortcuts } from '../../core/shortcuts/useShortcuts';
 import { ShortcutCode } from '../../core/shortcuts/shortcutConfiguration';
 import { DecomposerWorkItemTreeAreaRef } from './DecomposerWorkItemTreeArea';
+import { getShortcutDisplay } from '../../core/shortcuts/shortcutUtils';
 
 const actionBarLogger = logger.createChild('ActionBar');
 
@@ -112,7 +113,9 @@ export function DecomposerPanelActionBar(props: DecomposerPanelActionBarProps) {
           iconProps={{ iconName: 'Settings', size: IconSize.large }}
           onClick={handleOpenSettings}
           subtle
-          tooltipProps={{ text: 'Open Decomposer Settings' }}
+          tooltipProps={{
+            text: `Open Decomposer Settings (${getShortcutDisplay(ShortcutCode.ALT_COMMA)})`,
+          }}
           ariaLabel="Open Decomposer Settings"
           className="action-bar-settings-button"
         />
@@ -120,7 +123,9 @@ export function DecomposerPanelActionBar(props: DecomposerPanelActionBarProps) {
           iconProps={{ iconName: 'KeyboardClassic', size: IconSize.large }}
           onClick={onShowShortcutsHelp}
           subtle
-          tooltipProps={{ text: 'Show Keyboard Shortcuts' }}
+          tooltipProps={{
+            text: `Show Keyboard Shortcuts (${getShortcutDisplay(ShortcutCode.ALT_H)})`,
+          }}
           ariaLabel="Show Keyboard Shortcuts"
           className="action-bar-help-button"
         />
@@ -133,6 +138,7 @@ export function DecomposerPanelActionBar(props: DecomposerPanelActionBarProps) {
             onClick={handleSave}
             disabled={!canSave || isLoading || isAnyNodeInDeleteConfirmation}
             iconProps={isLoading ? undefined : { iconName: 'Save' }}
+            tooltipProps={{ text: `Save (${getShortcutDisplay(ShortcutCode.ALT_S)})` }}
           />
           {isLoading && <Spinner size={SpinnerSize.small} className="action-bar-spinner" />}
           <Button text="Discard" onClick={handleDiscard} disabled={isLoading} subtle />

--- a/src/components/decomposer/DecomposerPanelHeader.tsx
+++ b/src/components/decomposer/DecomposerPanelHeader.tsx
@@ -3,6 +3,8 @@ import { Button } from 'azure-devops-ui/Button';
 import { Pill, PillVariant } from 'azure-devops-ui/Pill';
 import { useGlobalState } from '../../context/GlobalStateProvider';
 import { getTextColorForBackground } from '../../core/common/common';
+import { getShortcutDisplay } from '../../core/shortcuts/shortcutUtils';
+import { ShortcutCode } from '../../core/shortcuts/shortcutConfiguration';
 import './DecomposerPanelHeader.scss';
 import { Spinner, SpinnerSize } from 'azure-devops-ui/Spinner';
 import { WorkItem } from 'azure-devops-extension-api/WorkItemTracking';
@@ -114,7 +116,7 @@ export function DecomposerPanelHeader(props: DecomposerPanelHeaderProps) {
       )}
       <div className="decomposer-panel-header-actions">
         <Button
-          tooltipProps={{ text: 'Add Child' }}
+          tooltipProps={{ text: `Add Child (${getShortcutDisplay(ShortcutCode.ALT_SHIFT_N)})` }}
           onClick={(event) => onAddRootItem(event)}
           disabled={!canAdd || !parentWorkItem || isAnyNodeInDeleteConfirmation}
           iconProps={{ iconName: 'Add' }}
@@ -122,7 +124,9 @@ export function DecomposerPanelHeader(props: DecomposerPanelHeaderProps) {
         />
         <div ref={showWitHierarchyViewerButtonContainerRef}>
           <Button
-            tooltipProps={{ text: 'View Type Hierarchy' }}
+            tooltipProps={{
+              text: `View Type Hierarchy (${getShortcutDisplay(ShortcutCode.ALT_SHIFT_H)})`,
+            }}
             onClick={handleShowWitHierarchyViewerClick}
             disabled={!projectName || !parentWorkItem}
             iconProps={{ iconName: 'ViewListTree' }}

--- a/src/components/modals/PromoteDemoteTypePicker/PromoteDemoteTypePickerModal.tsx
+++ b/src/components/modals/PromoteDemoteTypePicker/PromoteDemoteTypePickerModal.tsx
@@ -17,6 +17,7 @@ import { useFocusLock, FocusLockOptions } from '../../../core/hooks/useFocusLock
 import { useScrollVisibility } from '../../../core/hooks/useScrollVisibility';
 import { useContextShortcuts } from '../../../core/shortcuts/useShortcuts';
 import { ShortcutCode } from '../../../core/shortcuts/shortcutConfiguration';
+import { getShortcutDisplay } from '../../../core/shortcuts/shortcutUtils';
 import { WorkItemSection } from './WorkItemSection';
 
 interface PromoteDemoteTypePickerModalProps {
@@ -324,6 +325,7 @@ export function PromoteDemoteTypePickerModal({
               subtle
               ariaLabel="Close dialog"
               className="modal-close-button"
+              tooltipProps={{ text: `Close dialog (${getShortcutDisplay(ShortcutCode.ESCAPE)})` }}
             />
           </CustomHeader>
           <div className="modal-content-static">{headerDescription}</div>
@@ -365,6 +367,7 @@ export function PromoteDemoteTypePickerModal({
               subtle
               ariaLabel="Close dialog"
               className="modal-close-button"
+              tooltipProps={{ text: `Close dialog (${getShortcutDisplay(ShortcutCode.ESCAPE)})` }}
             />
           </CustomHeader>
 

--- a/src/components/modals/ShortcutHelpModal/ShortcutHelpModal.tsx
+++ b/src/components/modals/ShortcutHelpModal/ShortcutHelpModal.tsx
@@ -16,6 +16,7 @@ import {
   ShortcutVariant,
 } from '../../../core/shortcuts/ShortcutManager';
 import { ShortcutCode } from '../../../core/shortcuts/shortcutConfiguration';
+import { getShortcutDisplay, formatKeyCombo } from '../../../core/shortcuts/shortcutUtils';
 import './ShortcutHelpModal.scss';
 
 type ShortcutsByContextMap = Record<
@@ -90,6 +91,9 @@ export function ShortcutHelpModal({ isOpen, onClose }: ShortcutHelpModalProps) {
             subtle
             ariaLabel="Close help dialog"
             className="modal-close-button"
+            tooltipProps={{
+              text: `Close help dialog (${getShortcutDisplay(ShortcutCode.ESCAPE)})`,
+            }}
           />
         </CustomHeader>
 
@@ -105,7 +109,7 @@ export function ShortcutHelpModal({ isOpen, onClose }: ShortcutHelpModalProps) {
                   <div className="shortcut-list">
                     {contextShortcuts.map((shortcut, index) => (
                       <div key={`${shortcut.key}-${index}`} className="shortcut-item">
-                        <div className="shortcut-keys">{formatShortcutDisplay(shortcut.key)}</div>
+                        <div className="shortcut-keys">{formatKeyCombo(shortcut.key)}</div>
                         <div className="shortcut-description">{shortcut.variant.label}</div>
                       </div>
                     ))}
@@ -122,34 +126,4 @@ export function ShortcutHelpModal({ isOpen, onClose }: ShortcutHelpModalProps) {
       </Card>
     </div>
   );
-}
-
-function formatShortcutDisplay(keyCombo: string): string {
-  const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
-
-  return keyCombo
-    .split('+')
-    .map((part) => {
-      switch (part) {
-        case 'Ctrl':
-          return isMac ? '⌘' : 'Ctrl';
-        case 'Alt':
-          return isMac ? '⌥' : 'Alt';
-        case 'Shift':
-          return isMac ? '⇧' : 'Shift';
-        case 'ArrowUp':
-          return '↑';
-        case 'ArrowDown':
-          return '↓';
-        case 'ArrowLeft':
-          return '←';
-        case 'ArrowRight':
-          return '→';
-        case ' ':
-          return 'Space';
-        default:
-          return part;
-      }
-    })
-    .join(' + ');
 }

--- a/src/components/settings/AreaPathSelector.tsx
+++ b/src/components/settings/AreaPathSelector.tsx
@@ -513,6 +513,7 @@ export const AreaPathSelector: React.FC<AreaPathSelectorProps> = ({
                         }}
                         subtle
                         ariaLabel={item.isExpanded ? 'Collapse' : 'Expand'}
+                        tooltipProps={{ text: item.isExpanded ? 'Collapse' : 'Expand' }}
                       />
                     ) : (
                       <div className="expand-button-spacer" />

--- a/src/components/settings/HierarchySettingsPanel.tsx
+++ b/src/components/settings/HierarchySettingsPanel.tsx
@@ -35,6 +35,7 @@ export function HierarchySettingsPanel() {
         onClick={handleRefresh}
         disabled={isRefreshing}
         iconProps={{ iconName: 'Refresh' }}
+        tooltipProps={{ text: 'Refresh hierarchy data' }}
       />
     </div>
   );

--- a/src/components/settings/WitSettingsSection.tsx
+++ b/src/components/settings/WitSettingsSection.tsx
@@ -577,6 +577,7 @@ export function WitSettingsSection({
                 text="View Hierarchy Tree"
                 iconProps={{ iconName: 'ViewListTree' }}
                 onClick={handleViewHierarchy}
+                tooltipProps={{ text: 'View the work item type hierarchy' }}
               />
             </div>
           </div>

--- a/src/components/tree/WorkItemTreeNode.tsx
+++ b/src/components/tree/WorkItemTreeNode.tsx
@@ -15,6 +15,7 @@ import { TextField } from 'azure-devops-ui/TextField';
 import { useDeleteConfirmation } from '../../core/hooks/useDeleteConfirmation';
 import { useContextShortcuts } from '../../core/shortcuts/useShortcuts';
 import { ShortcutCode } from '../../core/shortcuts/shortcutConfiguration';
+import { getShortcutDisplay, formatKeyCombo } from '../../core/shortcuts/shortcutUtils';
 import './WorkItemTreeNode.scss';
 
 export interface WorkItemTreeNodeRef {
@@ -275,28 +276,6 @@ const WorkItemTreeNodeImpl = React.memo(
       onSelectWorkItem,
     ]);
 
-    // Helper function to format keyboard shortcuts for Mac/PC
-    const formatShortcutDisplay = (keyCombo: string): string => {
-      const isMac =
-        typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
-
-      return keyCombo
-        .split('+')
-        .map((part) => {
-          switch (part) {
-            case 'Alt':
-              return isMac ? '⌥' : 'Alt';
-            case 'Shift':
-              return isMac ? '⇧' : 'Shift';
-            case 'Ctrl':
-              return isMac ? '⌘' : 'Ctrl';
-            default:
-              return part;
-          }
-        })
-        .join('+');
-    };
-
     // Determine delete button styling based on settings and confirmation state
     const getDeleteButtonProps = () => {
       if (isConfirmingDelete) {
@@ -311,9 +290,12 @@ const WorkItemTreeNodeImpl = React.memo(
       };
     };
     const deleteButtonProps = getDeleteButtonProps();
+    const addTooltip = `Add a child item (${getShortcutDisplay(ShortcutCode.ALT_N)})`;
+    const promoteTooltip = `Promote item (${getShortcutDisplay(ShortcutCode.ALT_ARROW_LEFT)})`;
+    const demoteTooltip = `Demote item (${getShortcutDisplay(ShortcutCode.ALT_ARROW_RIGHT)})`;
     const deleteTooltipText = isConfirmingDelete
-      ? `Confirm deletion (${formatShortcutDisplay('Alt+Delete')})`
-      : 'Remove item and its children';
+      ? `Confirm deletion (${getShortcutDisplay(ShortcutCode.ALT_DELETE)})`
+      : `Delete item and its children (${getShortcutDisplay(ShortcutCode.ALT_DELETE)})`;
     const handleDeleteShortcutConfirm = useCallback(() => {
       if (isConfirmingDelete) {
         handleDeleteConfirm();
@@ -348,7 +330,7 @@ const WorkItemTreeNodeImpl = React.memo(
           <div className="delete-confirmation-message">
             <span className="delete-confirmation-text">
               Delete "{node.title}"{hasChildren ? ' and all its children' : ''}? Press{' '}
-              {formatShortcutDisplay('Alt+Delete')} to confirm or Esc to cancel.
+              {formatKeyCombo('Alt+Delete')} to confirm or Esc to cancel.
             </span>
           </div>
         )}
@@ -400,6 +382,7 @@ const WorkItemTreeNodeImpl = React.memo(
                 iconProps={{ iconName: 'Add' }}
                 subtle
                 aria-label="Add a child item"
+                tooltipProps={{ text: addTooltip }}
                 disabled={isAnyNodeConfirmingDelete}
               />
               <Button
@@ -407,6 +390,7 @@ const WorkItemTreeNodeImpl = React.memo(
                 iconProps={{ iconName: 'DoubleChevronLeft' }}
                 subtle
                 aria-label="Promote item"
+                tooltipProps={{ text: promoteTooltip }}
                 disabled={!node.canPromote || isAnyNodeConfirmingDelete}
               />
               {isConfirmingDelete ? (
@@ -417,7 +401,9 @@ const WorkItemTreeNodeImpl = React.memo(
                   className="delete-button-cancel"
                   subtle
                   aria-label="Cancel deletion"
-                  tooltipProps={{ text: 'Cancel deletion (Esc)' }}
+                  tooltipProps={{
+                    text: `Cancel deletion (${getShortcutDisplay(ShortcutCode.ESCAPE)})`,
+                  }}
                 />
               ) : (
                 <Button
@@ -425,6 +411,7 @@ const WorkItemTreeNodeImpl = React.memo(
                   iconProps={{ iconName: 'DoubleChevronRight' }}
                   subtle
                   aria-label="Demote item"
+                  tooltipProps={{ text: demoteTooltip }}
                   disabled={!node.canDemote || isAnyNodeConfirmingDelete}
                 />
               )}

--- a/src/core/shortcuts/shortcutUtils.ts
+++ b/src/core/shortcuts/shortcutUtils.ts
@@ -1,0 +1,64 @@
+import { ShortcutCode, SHORTCUT_CONFIGURATION } from './shortcutConfiguration';
+
+/**
+ * Gets the keyboard shortcut display string for a given ShortcutCode
+ * @param code The ShortcutCode enum value
+ * @returns The formatted keyboard shortcut string (e.g., "Alt+N", "Esc")
+ */
+export function getShortcutDisplay(code: ShortcutCode): string {
+  const shortcutDef = SHORTCUT_CONFIGURATION.find((s) => s.code === code);
+  if (!shortcutDef) {
+    return '';
+  }
+
+  // Format the key combo for display (handle special keys)
+  const keyCombo = shortcutDef.key;
+  return formatKeyCombo(keyCombo);
+}
+
+/**
+ * Formats a key combo string for display on different platforms
+ * @param keyCombo The key combo string (e.g., "Alt+N", "Ctrl+Delete")
+ * @returns The formatted key combo for display
+ */
+export function formatKeyCombo(keyCombo: string): string {
+  const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
+  return keyCombo
+    .split('+')
+    .map((part) => {
+      switch (part) {
+        case 'Ctrl':
+          return isMac ? '⌘' : 'Ctrl';
+        case 'Alt':
+          return isMac ? '⌥' : 'Alt';
+        case 'Shift':
+          return isMac ? '⇧' : 'Shift';
+        case 'Meta':
+          return isMac ? '⌘' : 'Win';
+        case 'ArrowUp':
+          return '↑';
+        case 'ArrowDown':
+          return '↓';
+        case 'ArrowLeft':
+          return '←';
+        case 'ArrowRight':
+          return '→';
+        case 'Escape':
+          return 'Esc';
+        case 'Delete':
+          return 'Del';
+        case 'Enter':
+          return 'Enter';
+        case ' ':
+          return 'Space';
+        case 'PageUp':
+          return 'PgUp';
+        case 'PageDown':
+          return 'PgDn';
+        default:
+          return part;
+      }
+    })
+    .join('+');
+}


### PR DESCRIPTION
## Description

This pull request improves the user experience by standardizing and enhancing the display of keyboard shortcut tooltips across the UI. It introduces a new utility, `getShortcutDisplay`, to consistently format and display shortcut keys, and applies this utility throughout various components. Additionally, it removes redundant shortcut formatting code from individual components, centralizing the logic for maintainability.

**Keyboard shortcut display improvements:**

* Added a new utility module `shortcutUtils.ts` with `getShortcutDisplay` and `formatKeyCombo` functions for consistent shortcut formatting across platforms.
* Updated all relevant components (such as `DecomposerPanelActionBar`, `DecomposerPanelHeader`, `WorkItemTreeNode`, `PromoteDemoteTypePickerModal`, and `ShortcutHelpModal`) to use `getShortcutDisplay` for tooltip text, ensuring shortcut keys are clearly and uniformly shown to users. [[1]](diffhunk://#diff-0eb52d5032dec627de3523625aa4f2dcbd18627a0cd0e4acf73deee3f9d48376R13) [[2]](diffhunk://#diff-0eb52d5032dec627de3523625aa4f2dcbd18627a0cd0e4acf73deee3f9d48376L115-R128) [[3]](diffhunk://#diff-0eb52d5032dec627de3523625aa4f2dcbd18627a0cd0e4acf73deee3f9d48376R141) [[4]](diffhunk://#diff-58c908f596a45eb5f051e64ef112e2568bc51305dd7978fbe8cc6d0d94374e0fR6-R7) [[5]](diffhunk://#diff-58c908f596a45eb5f051e64ef112e2568bc51305dd7978fbe8cc6d0d94374e0fL117-R129) [[6]](diffhunk://#diff-bb6e1a58aa20a9ca222ce42ebdf482e40982542641108db22f3550f5de31226fR20) [[7]](diffhunk://#diff-bb6e1a58aa20a9ca222ce42ebdf482e40982542641108db22f3550f5de31226fR328) [[8]](diffhunk://#diff-bb6e1a58aa20a9ca222ce42ebdf482e40982542641108db22f3550f5de31226fR370) [[9]](diffhunk://#diff-070e164913844daa17e42c0d9805bfb0ea7d26108004a50a97b85aad2933ceddR19) [[10]](diffhunk://#diff-070e164913844daa17e42c0d9805bfb0ea7d26108004a50a97b85aad2933ceddR94-R96) [[11]](diffhunk://#diff-785f929f1aed0728addb06689213e01a02f07edd04c92fe802be515b42889287R18) [[12]](diffhunk://#diff-785f929f1aed0728addb06689213e01a02f07edd04c92fe802be515b42889287R293-R298) [[13]](diffhunk://#diff-785f929f1aed0728addb06689213e01a02f07edd04c92fe802be515b42889287R385-R393) [[14]](diffhunk://#diff-785f929f1aed0728addb06689213e01a02f07edd04c92fe802be515b42889287L420-R414)

**Code cleanup and consistency:**

* Removed duplicate shortcut formatting helper functions from `WorkItemTreeNode` and `ShortcutHelpModal`, replacing them with the centralized `formatKeyCombo` utility. [[1]](diffhunk://#diff-785f929f1aed0728addb06689213e01a02f07edd04c92fe802be515b42889287L278-L299) [[2]](diffhunk://#diff-070e164913844daa17e42c0d9805bfb0ea7d26108004a50a97b85aad2933ceddL108-R112) [[3]](diffhunk://#diff-070e164913844daa17e42c0d9805bfb0ea7d26108004a50a97b85aad2933ceddL126-L155) [[4]](diffhunk://#diff-785f929f1aed0728addb06689213e01a02f07edd04c92fe802be515b42889287L351-R333)
* Updated the shortcut help modal to use `formatKeyCombo` for displaying key combinations, ensuring platform-specific symbols are used appropriately.

**General tooltip enhancements:**

* Added or improved tooltip text for various action buttons in settings and tree components, making shortcut hints more visible and user-friendly. [[1]](diffhunk://#diff-29276c6288b7db80fa894dec23c0f173a0457562c5bb3543616836ab9ba913f4R516) [[2]](diffhunk://#diff-8fac71125846009688814dd59a49823b7e5b6369b905b9955fe7f98f7964c9c7R38) [[3]](diffhunk://#diff-8a6794177f7cfd7670e6dbee617230b0e52581a0ce0175ef21b0d3c621774b7bR580)

These changes make keyboard shortcuts more discoverable and maintain a consistent user experience throughout the application.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update

## Testing

- [x] Changes have been tested in Azure DevOps
- [x] Works with different work item types
- [x] Responsive across different screen sizes

## Screenshots (if applicable)

_None_

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
